### PR TITLE
ci: 镜像发布前执行测试并升级 Actions

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -18,6 +18,16 @@ jobs:
   test:
     name: Maven Verify
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,4 +1,4 @@
-name: Build and Push with Jib
+name: Test, Build and Push with Jib
 
 on:
   push:
@@ -7,21 +7,67 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: gateway-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build-and-push:
+  test:
+    name: Maven Verify
     runs-on: ubuntu-latest
-    env:
-      REGISTRY_URL: 'ccr.ccs.tencentyun.com/opensabre' # 替换为你的镜像提交地址
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.6.0
         with:
-          java-version: '21' # 或你项目使用的JDK版本
+          java-version: '21'
           distribution: 'temurin'
+          cache: maven
+
+      - name: Run Tests
+        run: mvn --batch-mode --no-transfer-progress verify
+
+      - name: Upload Test Reports
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: test-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            target/surefire-reports/
+            target/failsafe-reports/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  build-and-push:
+    name: Build and Push Image
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_URL: 'ccr.ccs.tencentyun.com/opensabre'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
 
       - name: Build and Push with Jib
-        run: mvn compile jib:build -Dsecret.id=${{ secrets.DOCKER_CLOUD_SECRET_ID }} -Dsecret.key=${{ secrets.DOCKER_CLOUD_SECRET_KEY }}
+        run: >-
+          mvn --batch-mode --no-transfer-progress
+          -DskipTests
+          compile
+          jib:build
+          -Dsecret.id=${{ secrets.DOCKER_CLOUD_SECRET_ID }}
+          -Dsecret.key=${{ secrets.DOCKER_CLOUD_SECRET_KEY }}

--- a/src/test/java/io/github/opensabre/gateway/GatewayApplicationTests.java
+++ b/src/test/java/io/github/opensabre/gateway/GatewayApplicationTests.java
@@ -2,6 +2,8 @@ package io.github.opensabre.gateway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 
 @SpringBootTest(properties = {
         "spring.cloud.nacos.discovery.enabled=false",
@@ -14,6 +16,9 @@ import org.springframework.boot.test.context.SpringBootTest;
         "spring.security.oauth2.client.provider.custom-issuer.jwk-set-uri=http://localhost/oauth2/jwks"
 })
 public class GatewayApplicationTests {
+
+    @MockBean
+    private ReactiveClientRegistrationRepository clientRegistrationRepository;
 
     @Test
     public void contextLoads() {

--- a/src/test/java/io/github/opensabre/gateway/GatewayApplicationTests.java
+++ b/src/test/java/io/github/opensabre/gateway/GatewayApplicationTests.java
@@ -7,7 +7,11 @@ import org.springframework.boot.test.context.SpringBootTest;
         "spring.cloud.nacos.discovery.enabled=false",
         "spring.cloud.nacos.config.enabled=false",
         "spring.cloud.discovery.enabled=false",
-        "spring.cloud.gateway.discovery.locator.enabled=false"
+        "spring.cloud.gateway.discovery.locator.enabled=false",
+        "spring.security.oauth2.client.provider.custom-issuer.issuer-uri=",
+        "spring.security.oauth2.client.provider.custom-issuer.authorization-uri=http://localhost/oauth2/authorize",
+        "spring.security.oauth2.client.provider.custom-issuer.token-uri=http://localhost/oauth2/token",
+        "spring.security.oauth2.client.provider.custom-issuer.jwk-set-uri=http://localhost/oauth2/jwks"
 })
 public class GatewayApplicationTests {
 

--- a/src/test/java/io/github/opensabre/gateway/online/OnlineUserWebFilterTest.java
+++ b/src/test/java/io/github/opensabre/gateway/online/OnlineUserWebFilterTest.java
@@ -44,6 +44,7 @@ class OnlineUserWebFilterTest {
     @Test
     void invokesFilterChainOnlyOnceWithoutPrincipal() {
         when(exchange.getPrincipal()).thenReturn(Mono.empty());
+        when(exchange.getSession()).thenReturn(Mono.empty());
         when(chain.filter(exchange)).thenReturn(Mono.empty());
 
         filter.filter(exchange, chain).block();


### PR DESCRIPTION
## 变更
- PR 与发布流程先执行 `mvn verify`
- 测试失败时阻断镜像构建和发布
- 上传 Surefire/Failsafe 测试报告
- 升级 GitHub Actions 到当前稳定主版本
- 增加 Maven 缓存与并发取消