### PR TITLE
升级 Framework 至 0.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <opensabre.version>0.7.0</opensabre.version>
+        <opensabre.version>0.7.1</opensabre.version>
         <lombok.version>1.18.42</lombok.version>
         <swagger-core.version>2.2.25</swagger-core.version>
         <spring-boot-maven-plugin.version>3.4.1</spring-boot-maven-plugin.version>


### PR DESCRIPTION
## 变更\n- 将 OpenSabre Framework BOM/显式 starter 版本从 0.7.0 升级至 0.7.1\n\n## 验证\n- `mvn --batch-mode --no-transfer-progress verify` 通过\n\n0.7.1 已发布至 Maven Central。