### PR TITLE
feat: enforce API-level gateway routes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,25 +40,24 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
+        <!-- API 级熔断由 Spring Cloud Gateway 官方 reactive Resilience4j 适配器承载。 -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
+        </dependency>
         <!--WebFlux基础组件-->
         <dependency>
             <groupId>io.github.opensabre</groupId>
             <artifactId>opensabre-starter-webflux</artifactId>
         </dependency>
-        <!--开启Spring Cloud 应用程序启动时加载bootstrap配置文件-->
+        <!--统一使用 OpenSabre 注册中心和配置中心 starter。-->
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+            <groupId>io.github.opensabre</groupId>
+            <artifactId>opensabre-starter-register</artifactId>
         </dependency>
-        <!--注册中心-->
         <dependency>
-            <groupId>com.alibaba.cloud</groupId>
-            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
-        </dependency>
-        <!--配置中心-->
-        <dependency>
-            <groupId>com.alibaba.cloud</groupId>
-            <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+            <groupId>io.github.opensabre</groupId>
+            <artifactId>opensabre-starter-config</artifactId>
         </dependency>
         <!--redis限流-->
         <dependency>

--- a/src/main/java/io/github/opensabre/gateway/config/GatewayApiAccessProperties.java
+++ b/src/main/java/io/github/opensabre/gateway/config/GatewayApiAccessProperties.java
@@ -1,0 +1,34 @@
+package io.github.opensabre.gateway.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** 由网关控制面发布并随 Nacos 刷新的 API Method + Path 鉴权规则。 */
+@Data
+@Component
+@RefreshScope
+@ConfigurationProperties(prefix = "opensabre.gateway.api-access")
+public class GatewayApiAccessProperties {
+    private List<Rule> rules = new ArrayList<>();
+
+    /** 单条 API 访问规则；应用级通配路由不写入这里。 */
+    @Data
+    public static class Rule {
+        private String routeId;
+        private String method;
+        private String path;
+        private AccessMode mode;
+    }
+
+    /** API 对外入口的认证授权强度。 */
+    public enum AccessMode {
+        PUBLIC,
+        AUTHENTICATED,
+        RESOURCE_REQUIRED
+    }
+}

--- a/src/main/java/io/github/opensabre/gateway/config/Resilience4JGatewayConfiguration.java
+++ b/src/main/java/io/github/opensabre/gateway/config/Resilience4JGatewayConfiguration.java
@@ -1,0 +1,29 @@
+package io.github.opensabre.gateway.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.circuitbreaker.resilience4j.ReactiveResilience4JCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 保证 Sentinel 与 Resilience4j 共存时仍注册 Gateway 使用的 reactive Resilience4j 工厂。
+ * Sentinel 会先提供通用 ReactiveCircuitBreakerFactory，导致 Spring Cloud 的默认
+ * Resilience4j 自动配置退让，因此需要按具体类型补齐工厂。
+ */
+@Configuration(proxyBeanMethods = false)
+public class Resilience4JGatewayConfiguration {
+
+    /** 仅在 Resilience4j 专用工厂缺失时创建，不覆盖框架后续提供的原生实现。 */
+    @Bean
+    @ConditionalOnMissingBean(ReactiveResilience4JCircuitBreakerFactory.class)
+    public ReactiveResilience4JCircuitBreakerFactory reactiveResilience4JCircuitBreakerFactory(
+            CircuitBreakerRegistry circuitBreakerRegistry,
+            TimeLimiterRegistry timeLimiterRegistry,
+            Resilience4JConfigurationProperties properties) {
+        return new ReactiveResilience4JCircuitBreakerFactory(
+                circuitBreakerRegistry, timeLimiterRegistry, properties);
+    }
+}

--- a/src/main/java/io/github/opensabre/gateway/config/ResourceServerConfig.java
+++ b/src/main/java/io/github/opensabre/gateway/config/ResourceServerConfig.java
@@ -48,6 +48,8 @@ public class ResourceServerConfig {
 
         // 开启全局验证
         http.authorizeExchange((authorize) -> authorize
+                // 仅返回不透明发布修订号，供控制面逐实例确认配置已刷新。
+                .pathMatchers("/internal/gateway/revision", "/internal/gateway/routes/probe").permitAll()
                 // 不需要认证的资源或服务
                 .pathMatchers(opensabreGatewayConfig.getPermitPaths()).permitAll()
                 // url权限校验

--- a/src/main/java/io/github/opensabre/gateway/manager/DynamicAuthorizationManager.java
+++ b/src/main/java/io/github/opensabre/gateway/manager/DynamicAuthorizationManager.java
@@ -18,6 +18,8 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.util.Set;
+import java.util.Optional;
+import io.github.opensabre.gateway.config.GatewayApiAccessProperties;
 
 /**
  * 请求 url 动态鉴权
@@ -36,6 +38,12 @@ public class DynamicAuthorizationManager implements ReactiveAuthorizationManager
     @Value("${opensabre.gateway.permission.enabled:false}")
     private boolean permission;
 
+    private final GatewayApiAccessPolicy apiAccessPolicy;
+
+    public DynamicAuthorizationManager(GatewayApiAccessPolicy apiAccessPolicy) {
+        this.apiAccessPolicy = apiAccessPolicy;
+    }
+
     /**
      * url 级权限校验
      *
@@ -50,13 +58,34 @@ public class DynamicAuthorizationManager implements ReactiveAuthorizationManager
         if (exchange.getRequest().getMethod() == HttpMethod.OPTIONS) {
             return Mono.just(AUTHORIZATION_DECISION_TRUE);
         }
+        Optional<GatewayApiAccessProperties.AccessMode> apiMode;
+        try {
+            apiMode = apiAccessPolicy.resolve(exchange);
+        } catch (RuntimeException exception) {
+            // 动态规则损坏时失败关闭，不能退回更宽松的旧逻辑。
+            return Mono.just(AUTHORIZATION_DECISION_FALSE);
+        }
+        if (apiMode.orElse(null) == GatewayApiAccessProperties.AccessMode.PUBLIC) {
+            return Mono.just(AUTHORIZATION_DECISION_TRUE);
+        }
+        if (apiMode.orElse(null) == GatewayApiAccessProperties.AccessMode.AUTHENTICATED) {
+            return authenticated(authentication);
+        }
+        boolean forceResourcePermission = apiMode.orElse(null)
+                == GatewayApiAccessProperties.AccessMode.RESOURCE_REQUIRED;
         // 用户角色拥有的authorities 与 用户请求url所需authorities 进行匹配，任意包含则返回true(有权限)
         return authentication
                 // 认证通过的
                 .filter(Authentication::isAuthenticated)
                 // 用户token中的角色 所拥有的 authorities 和请求进行匹配
-                .flatMap(authToken -> hasPermission(authToken, exchange))
+                .flatMap(authToken -> hasPermission(authToken, exchange, forceResourcePermission))
                 // 如果为空则返回 false 无权限
+                .defaultIfEmpty(AUTHORIZATION_DECISION_FALSE);
+    }
+
+    private Mono<AuthorizationDecision> authenticated(Mono<Authentication> authentication) {
+        return authentication.filter(Authentication::isAuthenticated)
+                .map(ignored -> AUTHORIZATION_DECISION_TRUE)
                 .defaultIfEmpty(AUTHORIZATION_DECISION_FALSE);
     }
 
@@ -67,9 +96,10 @@ public class DynamicAuthorizationManager implements ReactiveAuthorizationManager
      * @param exchange  请求信息
      * @return Mono<AuthorizationDecision> 是否匹配
      */
-    private Mono<AuthorizationDecision> hasPermission(Authentication authToken, ServerWebExchange exchange) {
+    private Mono<AuthorizationDecision> hasPermission(Authentication authToken, ServerWebExchange exchange,
+            boolean forceResourcePermission) {
         // 如果权限开关关闭，则表示不进行url权限校验，则直接放行
-        if (!permission) {
+        if (!permission && !forceResourcePermission) {
             return Mono.just(AUTHORIZATION_DECISION_TRUE);
         }
         // 用户拥有的角色集合，从token中获取角色列表

--- a/src/main/java/io/github/opensabre/gateway/manager/GatewayApiAccessPolicy.java
+++ b/src/main/java/io/github/opensabre/gateway/manager/GatewayApiAccessPolicy.java
@@ -1,0 +1,35 @@
+package io.github.opensabre.gateway.manager;
+
+import io.github.opensabre.gateway.config.GatewayApiAccessProperties;
+import org.springframework.http.server.PathContainer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.util.Optional;
+
+/** 在现有角色资源鉴权前解析 API 级显式访问模式。 */
+@Component
+public class GatewayApiAccessPolicy {
+
+    private final GatewayApiAccessProperties properties;
+    private final PathPatternParser pathPatternParser = new PathPatternParser();
+
+    public GatewayApiAccessPolicy(GatewayApiAccessProperties properties) {
+        this.properties = properties;
+    }
+
+    /** 按 Method + PathPattern 返回首个 API 级规则；未命中时交回原权限逻辑。 */
+    public Optional<GatewayApiAccessProperties.AccessMode> resolve(ServerWebExchange exchange) {
+        String method = exchange.getRequest().getMethod().name();
+        PathContainer path = exchange.getRequest().getPath().pathWithinApplication();
+        for (GatewayApiAccessProperties.Rule rule : properties.getRules()) {
+            if (rule.getMode() == null || rule.getMethod() == null || rule.getPath() == null) continue;
+            if (method.equalsIgnoreCase(rule.getMethod())
+                    && pathPatternParser.parse(rule.getPath()).matches(path)) {
+                return Optional.of(rule.getMode());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/github/opensabre/gateway/rest/GatewayRevisionController.java
+++ b/src/main/java/io/github/opensabre/gateway/rest/GatewayRevisionController.java
@@ -1,0 +1,23 @@
+package io.github.opensabre.gateway.rest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/** 暴露当前实例实际加载的控制面发布修订号，供发布后生效确认使用。 */
+@RefreshScope
+@RestController
+public class GatewayRevisionController {
+
+    @Value("${opensabre.gateway.revision:UNMANAGED}")
+    private String revision;
+
+    /** 返回当前内存环境中的修订号，不读取 Nacos 最新值。 */
+    @GetMapping("/internal/gateway/revision")
+    public Map<String, String> revision() {
+        return Map.of("revision", revision);
+    }
+}

--- a/src/main/java/io/github/opensabre/gateway/rest/GatewayRouteProbeController.java
+++ b/src/main/java/io/github/opensabre/gateway/rest/GatewayRouteProbeController.java
@@ -1,0 +1,43 @@
+package io.github.opensabre.gateway.rest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/** 在不访问下游业务的情况下确认本实例已经构建预期的 Gateway Route。 */
+@RefreshScope
+@RestController
+public class GatewayRouteProbeController {
+
+    private final RouteLocator routeLocator;
+
+    @Value("${opensabre.gateway.revision:UNMANAGED}")
+    private String revision;
+
+    public GatewayRouteProbeController(RouteLocator routeLocator) {
+        this.routeLocator = routeLocator;
+    }
+
+    /** 修订号不一致时拒绝用旧实例路由表产生误导性探测结果。 */
+    @PostMapping("/internal/gateway/routes/probe")
+    public Mono<GatewayRouteProbeResponse> probe(@RequestBody GatewayRouteProbeRequest request) {
+        if (request.revision() == null || !request.revision().equals(revision)) {
+            return Mono.error(new IllegalStateException("实例尚未加载指定发布修订号"));
+        }
+        Set<String> expected = new LinkedHashSet<>(request.routeIds() == null ? List.of() : request.routeIds());
+        return routeLocator.getRoutes().map(route -> route.getId()).filter(expected::contains).collectList()
+                .map(loaded -> {
+                    Set<String> missing = new LinkedHashSet<>(expected);
+                    missing.removeAll(loaded);
+                    return new GatewayRouteProbeResponse(revision, List.copyOf(loaded), List.copyOf(missing));
+                });
+    }
+}

--- a/src/main/java/io/github/opensabre/gateway/rest/GatewayRouteProbeRequest.java
+++ b/src/main/java/io/github/opensabre/gateway/rest/GatewayRouteProbeRequest.java
@@ -1,0 +1,7 @@
+package io.github.opensabre.gateway.rest;
+
+import java.util.List;
+
+/** 控制面提交的本次发布修订号和预期托管 Route ID。 */
+public record GatewayRouteProbeRequest(String revision, List<String> routeIds) {
+}

--- a/src/main/java/io/github/opensabre/gateway/rest/GatewayRouteProbeResponse.java
+++ b/src/main/java/io/github/opensabre/gateway/rest/GatewayRouteProbeResponse.java
@@ -1,0 +1,7 @@
+package io.github.opensabre.gateway.rest;
+
+import java.util.List;
+
+/** 单个网关实例对预期 Route ID 的装载检查结果。 */
+public record GatewayRouteProbeResponse(String revision, List<String> loaded, List<String> missing) {
+}

--- a/src/test/java/io/github/opensabre/gateway/GatewayApplicationTests.java
+++ b/src/test/java/io/github/opensabre/gateway/GatewayApplicationTests.java
@@ -2,6 +2,11 @@ package io.github.opensabre.gateway;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.factory.SpringCloudCircuitBreakerResilience4JFilterFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = {
         "spring.cloud.nacos.discovery.enabled=false",
@@ -11,8 +16,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 })
 public class GatewayApplicationTests {
 
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @Test
     public void contextLoads() {
-
+        assertThat(applicationContext.getBeansOfType(SpringCloudCircuitBreakerResilience4JFilterFactory.class))
+                .isNotEmpty();
     }
 }

--- a/src/test/java/io/github/opensabre/gateway/config/Resilience4JGatewayConfigurationTest.java
+++ b/src/test/java/io/github/opensabre/gateway/config/Resilience4JGatewayConfigurationTest.java
@@ -1,0 +1,46 @@
+package io.github.opensabre.gateway.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JConfigurationProperties;
+import org.springframework.cloud.gateway.config.GatewayResilience4JCircuitBreakerAutoConfiguration;
+import org.springframework.cloud.gateway.filter.factory.SpringCloudCircuitBreakerResilience4JFilterFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 验证 Sentinel 已占用通用工厂场景下仍可装配 Gateway Resilience4j 过滤器。 */
+class Resilience4JGatewayConfigurationTest {
+
+    private final ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
+            .withUserConfiguration(TestDependencies.class,
+                    Resilience4JGatewayConfiguration.class,
+                    GatewayResilience4JCircuitBreakerAutoConfiguration.class);
+
+    @Test
+    void registersGatewayCircuitBreakerFilter() {
+        contextRunner.run(context -> assertThat(context)
+                .hasSingleBean(SpringCloudCircuitBreakerResilience4JFilterFactory.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class TestDependencies {
+        @Bean
+        CircuitBreakerRegistry circuitBreakerRegistry() {
+            return CircuitBreakerRegistry.ofDefaults();
+        }
+
+        @Bean
+        TimeLimiterRegistry timeLimiterRegistry() {
+            return TimeLimiterRegistry.ofDefaults();
+        }
+
+        @Bean
+        Resilience4JConfigurationProperties resilience4JConfigurationProperties() {
+            return new Resilience4JConfigurationProperties();
+        }
+    }
+}

--- a/src/test/java/io/github/opensabre/gateway/manager/DynamicAuthorizationManagerTest.java
+++ b/src/test/java/io/github/opensabre/gateway/manager/DynamicAuthorizationManagerTest.java
@@ -1,0 +1,91 @@
+package io.github.opensabre.gateway.manager;
+
+import io.github.opensabre.gateway.config.GatewayApiAccessProperties;
+import io.github.opensabre.gateway.entity.Authority;
+import io.github.opensabre.gateway.service.IAuthorityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** API 显式鉴权模式优先于旧的全局权限开关。 */
+class DynamicAuthorizationManagerTest {
+
+    private DynamicAuthorizationManager manager;
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        GatewayApiAccessProperties properties = new GatewayApiAccessProperties();
+        properties.setRules(List.of(
+                rule("GET", "/public", GatewayApiAccessProperties.AccessMode.PUBLIC),
+                rule("GET", "/profile", GatewayApiAccessProperties.AccessMode.AUTHENTICATED),
+                rule("GET", "/orders/{id}", GatewayApiAccessProperties.AccessMode.RESOURCE_REQUIRED)));
+        manager = new DynamicAuthorizationManager(new GatewayApiAccessPolicy(properties));
+        ReflectionTestUtils.setField(manager, "permission", false);
+        ReflectionTestUtils.setField(manager, "authorityService", authorityService());
+        authentication = new UsernamePasswordAuthenticationToken(
+                "user", "token", List.of(new SimpleGrantedAuthority("order-reader")));
+    }
+
+    @Test
+    void shouldAllowPublicWithoutAuthentication() {
+        assertThat(check(Mono.empty(), "GET", "/public")).isTrue();
+    }
+
+    @Test
+    void shouldRequireAuthenticationForAuthenticatedMode() {
+        assertThat(check(Mono.empty(), "GET", "/profile")).isFalse();
+        assertThat(check(Mono.just(authentication), "GET", "/profile")).isTrue();
+    }
+
+    @Test
+    void shouldForceResourcePermissionEvenWhenGlobalPermissionIsDisabled() {
+        assertThat(check(Mono.just(authentication), "GET", "/orders/42")).isTrue();
+        assertThat(check(Mono.empty(), "GET", "/orders/42")).isFalse();
+        assertThat(check(Mono.just(authentication), "POST", "/orders/42")).isTrue();
+    }
+
+    private boolean check(Mono<Authentication> auth, String method, String path) {
+        MockServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.method(org.springframework.http.HttpMethod.valueOf(method), path));
+        AuthorizationDecision decision = manager.check(auth, new AuthorizationContext(exchange)).block();
+        return decision != null && decision.isGranted();
+    }
+
+    private GatewayApiAccessProperties.Rule rule(String method, String path,
+            GatewayApiAccessProperties.AccessMode mode) {
+        GatewayApiAccessProperties.Rule rule = new GatewayApiAccessProperties.Rule();
+        rule.setMethod(method);
+        rule.setPath(path);
+        rule.setMode(mode);
+        return rule;
+    }
+
+    private IAuthorityService authorityService() {
+        return new IAuthorityService() {
+            @Override
+            public Flux<Authority> getAuthorityForRoles(String... roles) {
+                return Flux.just(new Authority("/orders/{id}", "GET", "order:view", "order-reader"));
+            }
+
+            @Override
+            public Flux<Authority> getAuthorityForRoles(Set<String> roles) {
+                return getAuthorityForRoles(roles.toArray(String[]::new));
+            }
+        };
+    }
+}

--- a/src/test/java/io/github/opensabre/gateway/rest/GatewayRevisionControllerTest.java
+++ b/src/test/java/io/github/opensabre/gateway/rest/GatewayRevisionControllerTest.java
@@ -1,0 +1,18 @@
+package io.github.opensabre.gateway.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 实例修订号端点只返回当前环境实际加载的值。 */
+class GatewayRevisionControllerTest {
+
+    @Test
+    void shouldReturnLoadedRevision() {
+        GatewayRevisionController controller = new GatewayRevisionController();
+        ReflectionTestUtils.setField(controller, "revision", "release-42");
+
+        assertThat(controller.revision()).containsEntry("revision", "release-42");
+    }
+}

--- a/src/test/java/io/github/opensabre/gateway/rest/GatewayRouteProbeControllerTest.java
+++ b/src/test/java/io/github/opensabre/gateway/rest/GatewayRouteProbeControllerTest.java
@@ -1,0 +1,34 @@
+package io.github.opensabre.gateway.rest;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Flux;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** 内部探测只检查本实例运行时 Route ID，不调用下游 URI。 */
+class GatewayRouteProbeControllerTest {
+
+    @Test
+    void shouldReturnMissingRouteIdsForLoadedRevision() {
+        RouteLocator locator = () -> Flux.just(route("api-1"), route("unmanaged"));
+        GatewayRouteProbeController controller = new GatewayRouteProbeController(locator);
+        ReflectionTestUtils.setField(controller, "revision", "release-11");
+
+        GatewayRouteProbeResponse response = controller.probe(
+                new GatewayRouteProbeRequest("release-11", List.of("api-1", "api-2"))).block();
+
+        assertThat(response.loaded()).containsExactly("api-1");
+        assertThat(response.missing()).containsExactly("api-2");
+    }
+
+    private Route route(String id) {
+        return Route.async().id(id).uri(URI.create("http://localhost"))
+                .predicate(exchange -> true).build();
+    }
+}


### PR DESCRIPTION
## Summary
- enforce API-specific PUBLIC/AUTHENTICATED/RESOURCE_REQUIRED access rules
- expose internal revision and route-load probe endpoints
- add Resilience4j circuit-breaker support
- reuse OpenSabre register/config starters

## Validation
- 6 focused tests passed
- git diff --check passed